### PR TITLE
Add admin voting reports

### DIFF
--- a/src/app/admin/reports/[editalSlug]/page.tsx
+++ b/src/app/admin/reports/[editalSlug]/page.tsx
@@ -1,0 +1,94 @@
+import PageTitle from "@/components/shared/PageTitle";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { db } from "@/firebase/client";
+import { collection, getDocs, query, where, doc, getDoc, Timestamp } from "firebase/firestore";
+import VotesReportTable, { ProjectReportData } from "@/components/admin/VotesReportTable";
+import { getEditalIdFromSlug } from "@/lib/slug-helpers";
+
+export default async function EditalReportPage({ params }: { params: { editalSlug: string } }) {
+  const { editalSlug } = params;
+  const editalId = await getEditalIdFromSlug(editalSlug);
+
+  if (!editalId) {
+    return <div className="text-center">Edital não encontrado.</div>;
+  }
+
+  const editalRef = doc(db, "editais", editalId);
+  const editalSnap = await getDoc(editalRef);
+  if (!editalSnap.exists()) {
+    return <div className="text-center">Edital não encontrado.</div>;
+  }
+  const editalData = editalSnap.data();
+  const editalName = editalData.name || "Edital";
+  const votingStartDate = editalData.votingStartDate instanceof Timestamp ? editalData.votingStartDate.toDate() : new Date();
+
+  const votesQuery = query(collection(db, "votes"), where("editalId", "==", editalId));
+  const votesSnap = await getDocs(votesQuery);
+  const votes = votesSnap.docs.map((d) => {
+    const data = d.data();
+    return {
+      projectId: data.projectId as string,
+      votedAt: data.votedAt instanceof Timestamp ? data.votedAt.toDate() : new Date(),
+    };
+  });
+
+  const now = new Date();
+  const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
+  const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const totalVotes = votes.length;
+  const votesLastHour = votes.filter((v) => v.votedAt >= oneHourAgo).length;
+  const votesLast24Hours = votes.filter((v) => v.votedAt >= twentyFourHoursAgo).length;
+
+  const hoursElapsed = Math.max((now.getTime() - votingStartDate.getTime()) / (1000 * 60 * 60), 1);
+  const daysElapsed = Math.max((now.getTime() - votingStartDate.getTime()) / (1000 * 60 * 60 * 24), 1);
+
+  const avgPerHour = totalVotes / hoursElapsed;
+  const avgPerDay = totalVotes / daysElapsed;
+
+  const projectsQuery = query(collection(db, "projects"), where("editalId", "==", editalId));
+  const projectsSnap = await getDocs(projectsQuery);
+  const projectStats: ProjectReportData[] = projectsSnap.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      projectName: data.projectName || "Projeto",
+      votesLastHour: 0,
+      votesLast24Hours: 0,
+      totalVotes: 0,
+    };
+  });
+  const projectIds = projectsSnap.docs.map((d) => d.id);
+  const statsMap: Record<string, ProjectReportData> = {};
+  projectIds.forEach((id, index) => {
+    statsMap[id] = projectStats[index];
+  });
+
+  votes.forEach((vote) => {
+    const stat = statsMap[vote.projectId];
+    if (stat) {
+      stat.totalVotes += 1;
+      if (vote.votedAt >= oneHourAgo) stat.votesLastHour += 1;
+      if (vote.votedAt >= twentyFourHoursAgo) stat.votesLast24Hours += 1;
+    }
+  });
+
+  return (
+    <div className="space-y-6">
+      <PageTitle>Relatório: {editalName}</PageTitle>
+      <Card>
+        <CardHeader>
+          <CardTitle>Estatísticas Gerais</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-1 text-sm">
+          <p>Total de votos: <strong>{totalVotes}</strong></p>
+          <p>Votos na última hora: <strong>{votesLastHour}</strong></p>
+          <p>Votos nas últimas 24 horas: <strong>{votesLast24Hours}</strong></p>
+          <p>Média por hora: <strong>{avgPerHour.toFixed(2)}</strong></p>
+          <p>Média por dia: <strong>{avgPerDay.toFixed(2)}</strong></p>
+        </CardContent>
+      </Card>
+      <VotesReportTable data={projectStats} />
+    </div>
+  );
+}
+

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,63 @@
+import PageTitle from "@/components/shared/PageTitle";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
+import { db } from "@/firebase/client";
+import { ArrowRight } from "lucide-react";
+
+interface SimpleEdital {
+  id: string;
+  name: string;
+  slug?: string;
+}
+
+async function fetchEditais(): Promise<SimpleEdital[]> {
+  try {
+    const editaisCollection = collection(db, "editais");
+    const q = query(editaisCollection, orderBy("createdAt", "desc"));
+    const snap = await getDocs(q);
+    return snap.docs.map((doc) => {
+      const data = doc.data();
+      return {
+        id: doc.id,
+        name: data.name || "Edital",
+        slug: data.slug || "",
+      };
+    });
+  } catch (err) {
+    console.error("Erro ao buscar editais", err);
+    return [];
+  }
+}
+
+export default async function ReportsPage() {
+  const editais = await fetchEditais();
+  return (
+    <div className="space-y-6">
+      <PageTitle>Relatórios</PageTitle>
+      {editais.length === 0 ? (
+        <p className="text-muted-foreground">Nenhum edital encontrado.</p>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {editais.map((edital) => (
+            <Card key={edital.id} className="shadow-md">
+              <CardHeader>
+                <CardTitle className="font-headline text-lg">{edital.name}</CardTitle>
+                <CardDescription>Visualizar estatísticas de votos.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild className="w-full">
+                  <Link href={`/admin/reports/${edital.slug || edital.id}`}>
+                    Ver Relatório <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/admin/VotesReportTable.tsx
+++ b/src/components/admin/VotesReportTable.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableCaption } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+
+export interface ProjectReportData {
+  projectName: string;
+  votesLastHour: number;
+  votesLast24Hours: number;
+  totalVotes: number;
+}
+
+interface VotesReportTableProps {
+  data: ProjectReportData[];
+}
+
+export default function VotesReportTable({ data }: VotesReportTableProps) {
+  const handleExport = () => {
+    const headers = ["Projeto", "Última Hora", "Últimas 24h", "Total de Votos"];
+    const rows = data.map((p) => [p.projectName, p.votesLastHour, p.votesLast24Hours, p.totalVotes]);
+    const csv = [headers, ...rows]
+      .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "votos_projetos.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button onClick={handleExport}>Exportar CSV</Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Projeto</TableHead>
+            <TableHead className="text-right">Última Hora</TableHead>
+            <TableHead className="text-right">Últimas 24h</TableHead>
+            <TableHead className="text-right">Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((proj) => (
+            <TableRow key={proj.projectName}>
+              <TableCell>{proj.projectName}</TableCell>
+              <TableCell className="text-right">{proj.votesLastHour}</TableCell>
+              <TableCell className="text-right">{proj.votesLast24Hours}</TableCell>
+              <TableCell className="text-right">{proj.totalVotes}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableCaption>Estatísticas de votos por projeto.</TableCaption>
+      </Table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add admin reports listing for editais
- add edital report page with voting stats
- export project vote data to CSV

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: two existing type errors)*


------
https://chatgpt.com/codex/tasks/task_e_6852797c10b483219a4a5e57f661e543