### PR TITLE
Add admin theme configuration

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -69,8 +69,8 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
             </SidebarMenu>
           </SidebarContent>
            <SidebarFooter className="p-2">
-             <SidebarMenuButton variant="ghost" className="justify-start text-muted-foreground hover:text-foreground">
-                <LogOut className="mr-2" /> Sair
+             <SidebarMenuButton variant="outline" className="justify-start text-muted-foreground hover:text-foreground">
+               <LogOut className="mr-2" /> Sair
              </SidebarMenuButton>
           </SidebarFooter>
         </Sidebar>

--- a/src/app/admin/theme/page.tsx
+++ b/src/app/admin/theme/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ThemeConfigSchema, type ThemeConfigData } from "@/lib/schemas";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import PageTitle from "@/components/shared/PageTitle";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { db } from "@/firebase/client";
+import { useToast } from "@/hooks/use-toast";
+
+export default function ThemePage() {
+  const { toast } = useToast();
+  const form = useForm<ThemeConfigData>({
+    resolver: zodResolver(ThemeConfigSchema),
+    defaultValues: {
+      palette: "blue",
+      heroTitle: "",
+      heroSubtitle: "",
+      heroImageUrl: "",
+    },
+  });
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const snap = await getDoc(doc(db, "config", "theme"));
+        if (snap.exists()) {
+          const data = snap.data() as ThemeConfigData;
+          form.reset({
+            palette: data.palette || "blue",
+            heroTitle: data.heroTitle || "",
+            heroSubtitle: data.heroSubtitle || "",
+            heroImageUrl: data.heroImageUrl || "",
+          });
+        }
+      } catch (err) {
+        console.error("Erro ao carregar configurações", err);
+      }
+    };
+    fetchConfig();
+  }, [form]);
+
+  async function onSubmit(values: ThemeConfigData) {
+    try {
+      await setDoc(doc(db, "config", "theme"), values, { merge: true });
+      toast({ title: "Configurações salvas" });
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Erro ao salvar", variant: "destructive" });
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <PageTitle>Personalizar Tema</PageTitle>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <Card className="shadow-lg">
+            <CardHeader>
+              <CardTitle>Paleta de Cores</CardTitle>
+              <CardDescription>Escolha uma das opções disponíveis</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FormField
+                control={form.control}
+                name="palette"
+                render={({ field }) => (
+                  <FormItem className="space-y-3">
+                    <FormControl>
+                      <RadioGroup
+                        className="flex flex-col gap-2"
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <FormItem className="flex items-center gap-2">
+                          <FormControl>
+                            <RadioGroupItem value="blue" />
+                          </FormControl>
+                          <FormLabel className="!m-0">Azul</FormLabel>
+                        </FormItem>
+                        <FormItem className="flex items-center gap-2">
+                          <FormControl>
+                            <RadioGroupItem value="green" />
+                          </FormControl>
+                          <FormLabel className="!m-0">Verde</FormLabel>
+                        </FormItem>
+                        <FormItem className="flex items-center gap-2">
+                          <FormControl>
+                            <RadioGroupItem value="wine" />
+                          </FormControl>
+                          <FormLabel className="!m-0">Vinho</FormLabel>
+                        </FormItem>
+                      </RadioGroup>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="shadow-lg">
+            <CardHeader>
+              <CardTitle>Conteúdo da Home</CardTitle>
+              <CardDescription>Frases e imagem exibidas na página inicial</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <FormField
+                control={form.control}
+                name="heroTitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Título Principal</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="heroSubtitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Subtítulo</FormLabel>
+                    <FormControl>
+                      <Textarea rows={3} {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="heroImageUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL da Imagem</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </CardContent>
+          </Card>
+
+          <Button type="submit" className="w-full">Salvar Configurações</Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,56 @@
+import React from 'react';
 import type { Metadata } from 'next';
 import './globals.css';
 import { Toaster } from '@/components/ui/toaster';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '@/firebase/client';
 
 export const metadata: Metadata = {
   title: 'Edital Participativo',
   description: 'Plataforma de editais participativos',
 };
 
-export default function RootLayout({
+type Palette = 'blue' | 'green' | 'wine';
+
+const paletteStyles: Record<Palette, Record<string, string>> = {
+  blue: {
+    '--primary': '198 90% 64%',
+    '--accent': '174 38% 64%',
+    '--background': '188 70% 93%',
+  },
+  green: {
+    '--primary': '152 60% 45%',
+    '--accent': '148 40% 40%',
+    '--background': '144 60% 92%',
+  },
+  wine: {
+    '--primary': '338 60% 40%',
+    '--accent': '330 40% 45%',
+    '--background': '350 60% 95%',
+  },
+};
+
+async function getThemePalette(): Promise<Palette> {
+  try {
+    const snap = await getDoc(doc(db, 'config', 'theme'));
+    if (snap.exists()) {
+      return (snap.data().palette as Palette) || 'blue';
+    }
+  } catch (err) {
+    console.error('Erro ao carregar paleta', err);
+  }
+  return 'blue';
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const palette = await getThemePalette();
+  const styleVars = paletteStyles[palette] || paletteStyles.blue;
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -21,9 +58,9 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
       </head>
-      <body 
+      <body
         className="font-body antialiased min-h-screen flex flex-col"
-        style={{ '--font-body': "'PT Sans', sans-serif" } as React.CSSProperties}
+        style={{ '--font-body': "'PT Sans', sans-serif", ...styleVars } as React.CSSProperties}
       >
         <Header />
         <main className="flex-grow container mx-auto px-4 py-8">

--- a/src/app/proponent/layout.tsx
+++ b/src/app/proponent/layout.tsx
@@ -49,8 +49,8 @@ export default function ProponentLayout({ children }: { children: ReactNode }) {
             </SidebarMenu>
           </SidebarContent>
           <SidebarFooter className="p-2">
-             <SidebarMenuButton variant="ghost" className="justify-start text-muted-foreground hover:text-foreground">
-                <LogOut className="mr-2" /> Sair
+             <SidebarMenuButton variant="outline" className="justify-start text-muted-foreground hover:text-foreground">
+               <LogOut className="mr-2" /> Sair
              </SidebarMenuButton>
           </SidebarFooter>
         </Sidebar>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -86,6 +86,13 @@ export const ProjectVoteSchema = z.object({
   phone: z.string().min(10, "Telefone inválido.").regex(/^\(?\d{2}\)?[\s-]?\d{4,5}-?\d{4}$/, "Formato de telefone inválido."),
 });
 
+export const ThemeConfigSchema = z.object({
+  palette: z.enum(["blue", "green", "wine"]),
+  heroTitle: z.string().min(3, "Título é obrigatório."),
+  heroSubtitle: z.string().min(3, "Subtítulo é obrigatório."),
+  heroImageUrl: z.string().url("URL inválida").optional().or(z.literal("")),
+});
+
 export type LoginFormData = z.infer<typeof LoginSchema>;
 export type SignupFormDataPhase1 = z.infer<typeof SignupSchemaPhase1>;
 export type ForgotPasswordFormData = z.infer<typeof ForgotPasswordSchema>;
@@ -94,3 +101,4 @@ export type EntityFormData = z.infer<typeof EntitySchema>;
 export type EditalCreateFormData = z.infer<typeof EditalCreateSchema>;
 export type ProjectSubmitFormData = z.infer<typeof ProjectSubmitSchema>;
 export type ProjectVoteFormData = z.infer<typeof ProjectVoteSchema>;
+export type ThemeConfigData = z.infer<typeof ThemeConfigSchema>;


### PR DESCRIPTION
## Summary
- add schema for theme configuration
- implement theme admin page with palette selection and hero text fields
- fetch theme settings in layout and home page
- adjust sidebar buttons and logout buttons

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685278755b988321b5f0a52fcb599ee5