### PR TITLE
Add vote confirmation workflow

### DIFF
--- a/src/app/api/confirm-vote/route.ts
+++ b/src/app/api/confirm-vote/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/firebase/client';
+import { collection, query, where, getDocs, addDoc, updateDoc, Timestamp } from 'firebase/firestore';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const token = searchParams.get('token');
+  if (!token) {
+    return NextResponse.json({ error: 'Token inválido' }, { status: 400 });
+  }
+
+  const pendingQuery = query(collection(db, 'pendingVotes'), where('token', '==', token));
+  const pendingSnap = await getDocs(pendingQuery);
+  if (pendingSnap.empty) {
+    return NextResponse.json({ error: 'Token não encontrado' }, { status: 404 });
+  }
+
+  const pendingDoc = pendingSnap.docs[0];
+  const data = pendingDoc.data();
+
+  if (data.status !== 'Pendente') {
+    return NextResponse.json({ message: 'Voto já confirmado' });
+  }
+
+  const duplicateQuery = query(
+    collection(db, 'votes'),
+    where('editalId', '==', data.editalId),
+    where('cpf', '==', data.cpf)
+  );
+  const duplicateSnap = await getDocs(duplicateQuery);
+
+  if (duplicateSnap.empty) {
+    await addDoc(collection(db, 'votes'), {
+      fullName: data.fullName,
+      cpf: data.cpf,
+      email: data.email,
+      phone: data.phone,
+      editalId: data.editalId,
+      projectId: data.projectId,
+      projectName: data.projectName,
+      votedAt: Timestamp.now(),
+    });
+    await updateDoc(pendingDoc.ref, { status: 'Válido' });
+    return NextResponse.json({ message: 'Voto confirmado' });
+  } else {
+    await updateDoc(pendingDoc.ref, { status: 'Duplicado' });
+    return NextResponse.json({ message: 'CPF já votou neste edital' });
+  }
+}

--- a/src/app/edital/[editalSlug]/[projectSlug]/page.tsx
+++ b/src/app/edital/[editalSlug]/[projectSlug]/page.tsx
@@ -9,6 +9,7 @@ import Image from "next/image";
 import { doc, getDoc, Timestamp } from "firebase/firestore";
 import { db } from "@/firebase/client";
 import { getProjectIdFromSlug, getEditalSlugFromId } from "@/lib/slug-helpers";
+import ProjectVoteForm from "@/components/edital/ProjectVoteForm";
 
 interface ProjectDetailsData {
   id: string;
@@ -213,6 +214,13 @@ export default async function ProjectDetailsPage({ params }: { params: Promise<{
             </Link>
         </CardFooter>
       </Card>
+      <div className="mt-8">
+        <ProjectVoteForm
+          editalId={project.editalId}
+          projectId={project.id}
+          projectName={project.name}
+        />
+      </div>
     </div>
   );
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,5 +1,6 @@
 
 import { z } from 'zod';
+import { validateCPF } from './utils';
 
 export const LoginSchema = z.object({
   email: z.string().email({ message: "Por favor, insira um email válido." }),
@@ -81,7 +82,10 @@ export const ProjectSubmitSchema = z.object({
 
 export const ProjectVoteSchema = z.object({
   fullName: z.string().min(3, "Nome completo é obrigatório."),
-  cpf: z.string().regex(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/, "CPF inválido. Use o formato XXX.XXX.XXX-XX."),
+  cpf: z
+    .string()
+    .regex(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/, "CPF inválido. Use o formato XXX.XXX.XXX-XX.")
+    .refine((val) => validateCPF(val), { message: "CPF inválido." }),
   email: z.string().email("Email inválido."),
   phone: z.string().min(10, "Telefone inválido.").regex(/^\(?\d{2}\)?[\s-]?\d{4,5}-?\d{4}$/, "Formato de telefone inválido."),
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,3 +28,25 @@ export function generateSlug(title: string): string {
     // Remove hífens do início e fim
     .replace(/^-|-$/g, '');
 }
+
+/**
+ * Valida CPF verificando os dígitos verificadores.
+ * Aceita formato XXX.XXX.XXX-XX ou apenas números.
+ */
+export function validateCPF(cpf: string): boolean {
+  const digits = cpf.replace(/[^0-9]/g, "");
+  if (digits.length !== 11 || /(\d)\1{10}/.test(digits)) return false;
+
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += parseInt(digits.charAt(i)) * (10 - i);
+  let firstCheck = (sum * 10) % 11;
+  if (firstCheck === 10) firstCheck = 0;
+  if (firstCheck !== parseInt(digits.charAt(9))) return false;
+
+  sum = 0;
+  for (let i = 0; i < 10; i++) sum += parseInt(digits.charAt(i)) * (11 - i);
+  let secondCheck = (sum * 10) % 11;
+  if (secondCheck === 10) secondCheck = 0;
+
+  return secondCheck === parseInt(digits.charAt(10));
+}


### PR DESCRIPTION
## Summary
- add CPF validation helper
- validate CPF in form schema
- create vote confirmation API route
- integrate ProjectVoteForm on project page
- enhance vote form with captcha and email confirmation flow

## Testing
- `npm run typecheck`
- `CI=true npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_68527e9616288321b69e8777e7942432